### PR TITLE
Dell P2715Q DisplayPort 1.2 and MST settings

### DIFF
--- a/graphics.md
+++ b/graphics.md
@@ -18,7 +18,10 @@ Monitors tested:
 
 - **P2715Q** (27" 4K): 3840x2160 over displayport connection `glxgears` reports 60 FPS (with native screen off).
   - With both native monitor and 27" on, the speed reported is higher, ~120 FPS, but actually looks less smooth
-  - the 27", 4K Dell doesn't have the option in the menu to enable displayport 1.2.
+  - DisplayPort 1.2 in enabled by default according to [Dell Knowledgebase article](http://www.dell.com/support/article/us/en/19/SLN296015/EN) and [P2715Q User Guide](http://content.etilize.com/User-Manual/1029519841.pdf):
+    - **MST Off: (DP1.2 mode for single monitor setup)** Default mode: 4k*2k 60Hz with MST function Disabled.
+    - **MST Primary: (DP1.2 mode for daisy chain setup)** MST function enabled for primary monitor in Daisy Chain setup. Expected resolution is 4k*2k 30Hz with MST (DP out) enabled.
+    - **MST Secondary: (DP1.1 for daisy chain and single display setup)** MST function disabled for secondary monitor in Daisy Chain setup Expected resolution is 4k*2k 30Hz with MST (DP out) disabled.
 
 - **U3415W** (34" Ultrasharp curved) DP 1.2 was enabled by default.  Selecting the full (3440x1440) resolution resulted in a blank screen; monitor could only display at lower resolution.  Turning off DP 1.2 allowed the display at full resolution, with `glxgears` reporting 60 FPS (whether or not laptop's native display was also on.)
 


### PR DESCRIPTION
I discovered your page here when I searched on github and your page came up as the first hit! :) Am troubleshooting the setup of my new P2715Q at home and ran into problems with my mid-2013 MacBook Air not getting the max resolution (when it should be able to).
